### PR TITLE
replaced Product with ProductDTO in ProductWithDateDTO

### DIFF
--- a/src/main/java/dev/itobey/adapter/api/fddb/exporter/dto/ProductWithDateDTO.java
+++ b/src/main/java/dev/itobey/adapter/api/fddb/exporter/dto/ProductWithDateDTO.java
@@ -1,6 +1,5 @@
 package dev.itobey.adapter.api.fddb.exporter.dto;
 
-import dev.itobey.adapter.api.fddb.exporter.domain.Product;
 import lombok.Data;
 
 import java.time.LocalDate;
@@ -9,6 +8,6 @@ import java.time.LocalDate;
 public class ProductWithDateDTO {
 
     private LocalDate date;
-    private Product product;
+    private ProductDTO product;
 
 }


### PR DESCRIPTION
Fixes the issue originally targeted for 1.6.1 but missed due to incomplete fix.